### PR TITLE
Add an `implementation_deps` argument to pom generation

### DIFF
--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -1,9 +1,9 @@
+load("//:specs.bzl", "parse", _json = "json")
 load(":javadoc.bzl", "javadoc")
 load(":maven_bom_fragment.bzl", "maven_bom_fragment")
 load(":maven_project_jar.bzl", "DEFAULT_EXCLUDED_WORKSPACES", "maven_project_jar")
 load(":maven_publish.bzl", "maven_publish")
 load(":pom_file.bzl", "pom_file")
-load("//:specs.bzl", "parse", _json = "json")
 
 def java_export(
         name,
@@ -12,6 +12,7 @@ def java_export(
         deploy_env = [],
         excluded_workspaces = {name: None for name in DEFAULT_EXCLUDED_WORKSPACES},
         exclusions = {},
+        implementation_deps = [],
         pom_template = None,
         visibility = None,
         tags = [],
@@ -75,6 +76,8 @@ def java_export(
       exclusions: Mapping of target labels to a list of exclusions to be added to the POM file.
         Each label must correspond to a direct maven dependency of this target.
         Each exclusion is represented as a `group:artifact` string.
+      implementation_deps: A list of labels of Java targets to include as 'implementation' dependencies. These are given
+        runtime scope on the generated pom file.
       classifier_artifacts: A dict of classifier -> artifact of additional artifacts to publish to Maven.
       doc_deps: Other `javadoc` targets that are referenced by the generated `javadoc` target
         (if not using `tags = ["no-javadoc"]`)
@@ -110,6 +113,7 @@ def java_export(
         deploy_env = deploy_env,
         excluded_workspaces = excluded_workspaces,
         exclusions = exclusions,
+        implementation_deps = implementation_deps,
         pom_template = pom_template,
         visibility = visibility,
         tags = tags,
@@ -129,6 +133,7 @@ def maven_export(
         deploy_env = [],
         excluded_workspaces = {},
         exclusions = {},
+        implementation_deps = [],
         pom_template = None,
         visibility = None,
         tags = [],
@@ -195,6 +200,8 @@ def maven_export(
       exclusions: Mapping of target labels to a list of exclusions to be added to the POM file.
         Each label must correspond to a direct maven dependency of this target.
         Each exclusion is represented as a `group:artifact` string.
+      implementation_deps: A list of labels of Java targets to include as 'implementation' dependencies. These are given
+        runtime scope on the generated pom file.
       doc_deps: Other `javadoc` targets that are referenced by the generated `javadoc` target
         (if not using `tags = ["no-javadoc"]`)
       doc_url: The URL at which the generated `javadoc` will be hosted (if not using
@@ -294,6 +301,7 @@ def maven_export(
         testonly = testonly,
         toolchains = toolchains,
         exclusions = exclusions_dict_json_strings,
+        implementation_deps = implementation_deps,
     )
 
     maven_publish(

--- a/private/rules/maven_utils.bzl
+++ b/private/rules/maven_utils.bzl
@@ -107,7 +107,8 @@ def generate_pom(
         versioned_dep_coordinates = [],
         unversioned_dep_coordinates = [],
         indent = 8,
-        exclusions = {}):
+        exclusions = {},
+        implementation_deps = []):
     unpacked_coordinates = unpack_coordinates(coordinates)
     substitutions = {
         "{groupId}": unpacked_coordinates.groupId,
@@ -137,12 +138,18 @@ def generate_pom(
         substitutions.update({"{parent}": "".join(parts)})
 
     deps = []
-    for dep in sorted(versioned_dep_coordinates):
+    for dep in sorted(versioned_dep_coordinates + unversioned_dep_coordinates):
+        include_version = dep in versioned_dep_coordinates
         unpacked = unpack_coordinates(dep)
-        deps.append(format_dep(unpacked, indent = indent, exclusions = exclusions.get(dep, {})))
-    for dep in sorted(unversioned_dep_coordinates):
-        unpacked = unpack_coordinates(dep)
-        deps.append(format_dep(unpacked, indent = indent, exclusions = exclusions.get(dep, {}), include_version = False))
+        new_scope = "runtime" if dep in implementation_deps else unpacked.scope
+        unpacked = struct(
+            groupId = unpacked.groupId,
+            artifactId = unpacked.artifactId,
+            type = unpacked.type,
+            scope = new_scope,
+            version = unpacked.version,
+        )
+        deps.append(format_dep(unpacked, indent = indent, exclusions = exclusions.get(dep, {}), include_version = include_version))
 
     substitutions.update({"{dependencies}": "\n".join(deps)})
 

--- a/private/rules/maven_utils.bzl
+++ b/private/rules/maven_utils.bzl
@@ -138,7 +138,7 @@ def generate_pom(
         substitutions.update({"{parent}": "".join(parts)})
 
     deps = []
-    for dep in sorted(versioned_dep_coordinates + unversioned_dep_coordinates):
+    for dep in sorted(versioned_dep_coordinates) + sorted(unversioned_dep_coordinates):
         include_version = dep in versioned_dep_coordinates
         unpacked = unpack_coordinates(dep)
         new_scope = "runtime" if dep in implementation_deps else unpacked.scope

--- a/private/rules/pom_file.bzl
+++ b/private/rules/pom_file.bzl
@@ -18,8 +18,6 @@ def _pom_file_impl(ctx):
         else:
             return ctx.expand_make_variables("exclusions", target[MavenInfo].coordinates, ctx.var)
 
-    # TODO I'd rather not fail when a coordinate is not found, that way we can automate just dumping the whole
-    #  dep list into here. Should we do the same thing for exclusions?
     def get_implementation_coordinates(target):
         if not info.label_to_javainfo.get(target.label):
             return None

--- a/private/rules/pom_file.bzl
+++ b/private/rules/pom_file.bzl
@@ -12,18 +12,32 @@ def _pom_file_impl(ctx):
     artifact_jars = calculate_artifact_jars(info)
     additional_deps = determine_additional_dependencies(artifact_jars, ctx.attr.additional_dependencies)
 
-    def get_coordinates(target):
+    def get_exclusion_coordinates(target):
         if not info.label_to_javainfo.get(target.label):
             fail("exclusions key %s not found in dependencies %s" % (target, info.label_to_javainfo.keys()))
         else:
             return ctx.expand_make_variables("exclusions", target[MavenInfo].coordinates, ctx.var)
 
+    # TODO I'd rather not fail when a coordinate is not found, that way we can automate just dumping the whole
+    #  dep list into here. Should we do the same thing for exclusions?
+    def get_implementation_coordinates(target):
+        if not info.label_to_javainfo.get(target.label):
+            return None
+        if not target[MavenInfo].coordinates:
+            return None
+
+        return ctx.expand_make_variables("implementation_deps", target[MavenInfo].coordinates, ctx.var)
+
     exclusions = {
-        get_coordinates(target): json.decode(targetExclusions)
+        get_exclusion_coordinates(target): json.decode(targetExclusions)
         for target, targetExclusions in ctx.attr.exclusions.items()
     }
 
-    implementation_deps = [get_coordinates(target) for target in ctx.attr.implementation_deps]
+    implementation_deps = [
+        get_implementation_coordinates(target)
+        for target in ctx.attr.implementation_deps
+    ]
+    implementation_deps = [dep for dep in implementation_deps if dep]
 
     all_maven_deps = info.maven_deps.to_list()
     for dep in additional_deps:

--- a/private/rules/pom_file.bzl
+++ b/private/rules/pom_file.bzl
@@ -23,6 +23,8 @@ def _pom_file_impl(ctx):
         for target, targetExclusions in ctx.attr.exclusions.items()
     }
 
+    implementation_deps = [get_coordinates(target) for target in ctx.attr.implementation_deps]
+
     all_maven_deps = info.maven_deps.to_list()
     for dep in additional_deps:
         for coords in dep[MavenInfo].as_maven_dep.to_list():
@@ -42,6 +44,7 @@ def _pom_file_impl(ctx):
         pom_template = ctx.file.pom_template,
         out_name = "%s.xml" % ctx.label.name,
         exclusions = exclusions,
+        implementation_deps = implementation_deps,
     )
 
     return [
@@ -97,6 +100,13 @@ The following substitutions are performed on the template file:
         ),
         "exclusions": attr.label_keyed_string_dict(
             doc = "Mapping of dependency labels to a list of exclusions (encoded as a json string). Each exclusion is a dict with a group and an artifact.",
+            allow_empty = True,
+            aspects = [
+                has_maven_deps,
+            ],
+        ),
+        "implementation_deps": attr.label_list(
+            doc = "A list of labels of Java targets to include as 'implementation' dependencies. These are given runtime scope on the generated pom file.",
             allow_empty = True,
             aspects = [
                 has_maven_deps,


### PR DESCRIPTION
In Gradle builds, there is a concept of `implementation` dependencies.
These dependencies are available at compile time for the project, but are defined as "runtime" in the pom file for downstream projects.
This adds a similar concept to Bazel builds. It allows for `deps` to be defined as `runtime` only for the generated pom file.