### PR TITLE
Skip non-class files in the exclusions processing

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/MergeJars.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/MergeJars.java
@@ -119,8 +119,7 @@ public class MergeJars {
     manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
 
     Map<String, Set<String>> allServices = new TreeMap<>();
-    Set<String> excludedPaths = readExcludedFileNames(excludes);
-    Set<String> duplicateExceptions = Set.of("COPYRIGHT", "LICENSE", "NOTICE");
+    Set<String> excludedPaths = readExcludedClassNames(excludes);
 
     // Ultimately, we want the entries in the output zip to be sorted
     // so that we have a deterministic output.
@@ -141,7 +140,6 @@ public class MergeJars {
 
           if ("META-INF/".equals(entry.getName())
               || (!entry.getName().startsWith("META-INF/")
-                  && !duplicateExceptions.contains(entry.getName())
                   && excludedPaths.contains(entry.getName()))) {
             continue;
           }
@@ -319,7 +317,7 @@ public class MergeJars {
     }
   }
 
-  private static Set<String> readExcludedFileNames(Set<Path> excludes) throws IOException {
+  private static Set<String> readExcludedClassNames(Set<Path> excludes) throws IOException {
     Set<String> paths = new HashSet<>();
 
     for (Path exclude : excludes) {
@@ -329,6 +327,9 @@ public class MergeJars {
         ZipEntry entry;
         while ((entry = jis.getNextEntry()) != null) {
           if (entry.isDirectory()) {
+            continue;
+          }
+          if (!entry.getName().endsWith(".class")) {
             continue;
           }
 

--- a/tests/com/github/bazelbuild/rules_jvm_external/jar/MergeJarsTest.java
+++ b/tests/com/github/bazelbuild/rules_jvm_external/jar/MergeJarsTest.java
@@ -615,6 +615,35 @@ public class MergeJarsTest {
     assertEquals(prepend + "\ncom.example.Foo\n", contents.get("META-INF/services/com.example.ServiceProvider"));
   }
 
+  @Test
+  public void mergedJarKeepsNonClassFiles() throws IOException {
+    Path inputOne = temp.newFile("one.jar").toPath();
+    createJar(
+        inputOne,
+        ImmutableMap.of("log4j.properties", "log4j.rootLogger=ERROR,stdout")
+    );
+
+    Path excludeOne = temp.newFile("two.jar").toPath();
+    createJar(
+        excludeOne,
+        ImmutableMap.of("log4j.properties", "log4j.rootLogger=ERROR")
+    );
+
+    Path outputJar = temp.newFile("out.jar").toPath();
+
+    MergeJars.main(
+        new String[] {
+            "--output", outputJar.toAbsolutePath().toString(),
+            "--sources", inputOne.toAbsolutePath().toString(),
+            "--exclude", excludeOne.toAbsolutePath().toString(),
+        });
+
+    Map<String, String> contents = readJar(outputJar);
+
+    assertEquals("log4j.rootLogger=ERROR,stdout", contents.get("log4j.properties"));
+
+  }
+
   private void createJar(Path outputTo, Map<String, String> pathToContents) throws IOException {
     try (OutputStream os = Files.newOutputStream(outputTo);
         ZipOutputStream zos = new ZipOutputStream(os)) {


### PR DESCRIPTION
[opened a PR ](
https://github.com/bazelbuild/rules_jvm_external/pull/1125)upstream that may end up differing based on feedback, but I think this is good enough to merge in to unblock our own use case. All `MergeJarTest` tests are still passing with this change, and more jars are passing as equivalent to the Gradle versions.
