### PR TITLE
remove 'prepend-services' feature

### DIFF
--- a/private/rules/java_export.bzl
+++ b/private/rules/java_export.bzl
@@ -17,7 +17,6 @@ def java_export(
         tags = [],
         testonly = None,
         classifier_artifacts = {},
-        prepend_services = None,
         **kwargs):
     """Extends `java_library` to allow maven artifacts to be uploaded.
 
@@ -77,7 +76,6 @@ def java_export(
         Each label must correspond to a direct maven dependency of this target.
         Each exclusion is represented as a `group:artifact` string.
       classifier_artifacts: A dict of classifier -> artifact of additional artifacts to publish to Maven.
-      prepend_services: A file whose contents will be prepended to the generated `META-INF/services` files in the -project jar.
       doc_deps: Other `javadoc` targets that are referenced by the generated `javadoc` target
         (if not using `tags = ["no-javadoc"]`)
       doc_url: The URL at which the generated `javadoc` will be hosted (if not using
@@ -118,7 +116,6 @@ def java_export(
         testonly = testonly,
         javadocopts = javadocopts,
         classifier_artifacts = classifier_artifacts,
-        prepend_services = prepend_services,
         doc_deps = doc_deps,
         doc_url = doc_url,
         toolchains = toolchains,
@@ -138,7 +135,6 @@ def maven_export(
         testonly = False,
         javadocopts = [],
         classifier_artifacts = {},
-        prepend_services = None,
         *,
         doc_deps = [],
         doc_url = "",
@@ -199,7 +195,6 @@ def maven_export(
       exclusions: Mapping of target labels to a list of exclusions to be added to the POM file.
         Each label must correspond to a direct maven dependency of this target.
         Each exclusion is represented as a `group:artifact` string.
-      prepend_services: A file whose contents will be prepended to the generated `META-INF/services` files in the -project jar.
       doc_deps: Other `javadoc` targets that are referenced by the generated `javadoc` target
         (if not using `tags = ["no-javadoc"]`)
       doc_url: The URL at which the generated `javadoc` will be hosted (if not using
@@ -232,7 +227,6 @@ def maven_export(
         deploy_env = deploy_env,
         excluded_workspaces = excluded_workspaces.keys(),
         additional_dependencies = additional_dependencies,
-        prepend_services = prepend_services,
         visibility = visibility,
         tags = tags + maven_coordinates_tags,
         testonly = testonly,

--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/MergeJars.java
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/jar/MergeJars.java
@@ -46,7 +46,6 @@ import java.util.TreeMap;
 import java.util.jar.Attributes;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
@@ -55,7 +54,6 @@ public class MergeJars {
 
   public static void main(String[] args) throws IOException {
     Path out = null;
-    Path prependServices = null;
     // Insertion order may matter
     Set<Path> sources = new LinkedHashSet<>();
     Set<Path> excludes = new HashSet<>();
@@ -82,11 +80,6 @@ public class MergeJars {
 
         case "--sources":
           sources.add(isValid(Paths.get(args[++i])));
-          break;
-
-        case "--prepend_services":
-          isValid(Paths.get(args[++i]));
-          prependServices = Paths.get(args[i]);
           break;
 
         default:


### PR DESCRIPTION
This is no longer used since https://github.com/confluentinc/rules_jvm_external/pull/11 was introduced