### PR TITLE
DP-14758 - add classifier to generated pom

### DIFF
--- a/private/rules/maven_utils.bzl
+++ b/private/rules/maven_utils.bzl
@@ -1,10 +1,10 @@
 def unpack_coordinates(coords):
     """Takes a maven coordinate and unpacks it into a struct with fields
-    `groupId`, `artifactId`, `version`, `type`, `scope`
+    `groupId`, `artifactId`, `version`, `type`, `classifier`
     where type and scope are optional.
 
     Assumes following maven coordinate syntax:
-    groupId:artifactId[:type[:scope]]:version
+    groupId:artifactId[:type[:classifer]]:version
     """
     if not coords:
         return None
@@ -18,6 +18,7 @@ def unpack_coordinates(coords):
             artifactId = parts[1],
             type = None,
             scope = None,
+            classifier = None,
             version = None,
         )
 
@@ -30,7 +31,8 @@ def unpack_coordinates(coords):
         groupId = parts.get(0),
         artifactId = parts.get(1),
         type = parts.get(2),
-        scope = parts.get(3),
+        scope = None,
+        classifier = parts.get(4),
         version = version,
     )
 
@@ -68,6 +70,12 @@ def format_dep(unpacked, indent = 8, include_version = True, exclusions = {}):
         dependency.extend([
             whitespace,
             "    <scope>%s</scope>\n" % unpacked.scope,
+        ])
+
+    if unpacked.classifier:
+        dependency.extend([
+            whitespace,
+            "    <classifier>%s</classifier>\n" % unpacked.classifier,
         ])
 
     if exclusions:
@@ -115,6 +123,7 @@ def generate_pom(
         "{artifactId}": unpacked_coordinates.artifactId,
         "{version}": unpacked_coordinates.version,
         "{type}": unpacked_coordinates.type or "jar",
+        "{classifier}": unpacked_coordinates.classifier or "",
         "{scope}": unpacked_coordinates.scope or "compile",
     }
 
@@ -147,6 +156,7 @@ def generate_pom(
             artifactId = unpacked.artifactId,
             type = unpacked.type,
             scope = new_scope,
+            classifier = unpacked.classifier,
             version = unpacked.version,
         )
         deps.append(format_dep(unpacked, indent = indent, exclusions = exclusions.get(dep, {}), include_version = include_version))

--- a/private/rules/maven_utils.bzl
+++ b/private/rules/maven_utils.bzl
@@ -32,7 +32,7 @@ def unpack_coordinates(coords):
         artifactId = parts.get(1),
         type = parts.get(2),
         scope = None,
-        classifier = parts.get(4),
+        classifier = parts.get(3),
         version = version,
     )
 


### PR DESCRIPTION
This fixes https://github.com/bazelbuild/rules_jvm_external/issues/1154

It seems like a bug that scope was being considered in the maven coordinates. I couldn't find any examples of that being the case. But it is common for `group:artifact:version:type:classifier`.

Demo of the issue: https://github.com/vinnybod/bazel_java_example/tree/classifier-pom

Will open upstream PR after.