### PR TITLE
Revert "handle transitive dependencies of packaging=pom (#1207)" (#4)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -711,16 +711,6 @@ dev_maven.install(
     lock_file = "//tests/custom_maven_install:v1_lock_file_format_install.json",
 )
 
-# https://github.com/bazelbuild/rules_jvm_external/issues/1206
-dev_maven.install(
-    name = "transitive_dependency_with_type_of_pom",
-    # an arbitrary artifact which depends on org.javamoney:moneta:pom
-    artifacts = [
-        # https://github.com/quarkiverse/quarkus-moneta/blob/2.0.0/runtime/pom.xml#L16-L21
-        "io.quarkiverse.moneta:quarkus-moneta:2.0.0",
-    ],
-)
-
 # Where there are file locks, the pinned and unpinned repos are listed
 # next to each other. Where compat repositories are created, they are
 # listed next to the repo that created them. The list is otherwise kept
@@ -812,7 +802,6 @@ use_repo(
     # Final entries
     "com_google_http_client_google_http_client",
     "testonly_testing",
-    "transitive_dependency_with_type_of_pom",
     "unpinned_v1_lock_file_format",
     "v1_lock_file_format",
     "version_interval_testing",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -915,16 +915,3 @@ maven_install(
 load("@maven_resolved_with_boms//:defs.bzl", _maven_resolved_maven_install = "pinned_maven_install")
 
 _maven_resolved_maven_install()
-
-# https://github.com/bazelbuild/rules_jvm_external/issues/1206
-maven_install(
-    name = "transitive_dependency_with_type_of_pom",
-    # an arbitrary artifact which depends on org.javamoney:moneta:pom
-    artifacts = [
-        # https://github.com/quarkiverse/quarkus-moneta/blob/2.0.0/runtime/pom.xml#L16-L21
-        "io.quarkiverse.moneta:quarkus-moneta:2.0.0",
-    ],
-    repositories = [
-        "https://repo1.maven.org/maven2",
-    ],
-)

--- a/private/coursier_utilities.bzl
+++ b/private/coursier_utilities.bzl
@@ -32,7 +32,6 @@ SUPPORTED_PACKAGING_TYPES = [
     "dylib",
     "so",
     "dll",
-    "pom",
 ]
 
 # See https://github.com/bazelbuild/rules_jvm_external/issues/686

--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -404,7 +404,6 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
         if skip_maven_local_dependencies and is_maven_local_path(artifact_path):
             continue
         simple_coord = strip_packaging_and_classifier_and_version(artifact["coordinates"])
-        packaging = get_packaging(artifact["coordinates"])
         target_label = escape(simple_coord)
         alias_visibility = ""
 
@@ -419,7 +418,7 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
             all_imports.append(
                 "filegroup(\n\tname = \"%s\",\n\tsrcs = [\"%s\"],\n\ttags = [\"javadoc\"],\n\tvisibility = [\"//visibility:public\"],\n)" % (target_label, artifact_path),
             )
-        elif packaging in ("exe", "json"):
+        elif get_packaging(artifact["coordinates"]) in ("exe", "json"):
             seen_imports[target_label] = True
             versioned_target_alias_label = "%s_extension" % escape(artifact["coordinates"])
             all_imports.append(
@@ -455,7 +454,7 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
                 raw_artifact,
             ))
 
-        elif artifact_path != None and packaging != "pom":
+        elif artifact_path != None:
             seen_imports[target_label] = True
             all_imports.extend(_generate_target(
                 repository_ctx,
@@ -469,7 +468,7 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
                 default_visibilities,
                 artifact,
             ))
-        else:  # artifact_path == None or packaging == "pom":
+        else:  # artifact_path == None:
             # Special case for certain artifacts that only come with a POM file.
             # Such artifacts "aggregate" their dependencies, so they don't have
             # a JAR for download.

--- a/tests/bazel_run_tests.sh
+++ b/tests/bazel_run_tests.sh
@@ -251,14 +251,6 @@ function test_maven_resolution() {
     bazel run @maven_resolved_with_boms//:pin >> "$TEST_LOG" 2>&1
 }
 
-function test_transitive_dependency_with_type_of_pom {
-  # transitive_dependency_with_type_of_pom installs an artifact which depends on
-  # org.javamoney:moneta:pom, which should expand into the transitive
-  # dependencies of that type=pom artifact, such as
-  # org.javamoney.moneta:moneta-core
-  bazel query @transitive_dependency_with_type_of_pom//:org_javamoney_moneta_moneta_core >> "$TEST_LOG" 2>&1
-}
-
 TESTS=(
   "test_maven_resolution"
   "test_dependency_aggregation"
@@ -276,7 +268,6 @@ TESTS=(
   "test_unpinned_found_artifact_with_plus_through_pin_and_build"
   "test_v1_lock_file_format"
   "test_dependency_pom_exclusion"
-  "test_transitive_dependency_with_type_of_pom"
 )
 
 function run_tests() {


### PR DESCRIPTION
This reverts commit 6ccd884724480828ed5947dad03ece4560f1d7dc.

revert this commit since rules_jvm_external added support for pom. https://github.com/confluentinc/ce-kafka/blob/a2ffea696ad6dae0b8a5dab46a008ff160951829/dependencies/maven_install.json#L7000 is removed and instead it is using com.github.spotbugs:spotbugs:pom . It causes error . To unblock, revert this commit and then we will try to figure out the issue later.

```
Error: Could not find or load main class edu.umd.cs.findbugs.LaunchAppropriateUI
Caused by: java.lang.ClassNotFoundException: edu.umd.cs.findbugs.LaunchAppropriateUI
```