### PR TITLE
Remove deploy_env for scala_export

### DIFF
--- a/private/rules/scala_export.bzl
+++ b/private/rules/scala_export.bzl
@@ -5,10 +5,7 @@ load(":maven_project_jar.bzl", "DEFAULT_EXCLUDED_WORKSPACES")
 
 scala_doc = make_scala_doc_rule(aspect = scaladoc_intransitive_aspect)
 
-SCALA_LIBS = [
-    "@io_bazel_rules_scala_scala_library//jar",
-    "@io_bazel_rules_scala_scala_reflect//jar",
-]
+SCALA_LIBS = []
 
 def scala_export(
         name,


### PR DESCRIPTION
These were originally added when I adapted this rule from the kt_export rule.
Adding these to deploy_env instead of workspace exclusions (which we already do) makes them appear in the javadocs output, which we don't want.