### PR TITLE
Add missing commons-logging dependency to MavenPublisherLib

### DIFF
--- a/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/BUILD
+++ b/private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/BUILD
@@ -22,6 +22,10 @@ java_library(
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/remote",
         "//private/tools/java/com/github/bazelbuild/rules_jvm_external/resolver/ui",
         artifact(
+            "commons-logging:commons-logging",
+            repository_name = "rules_jvm_external_deps",
+        ),
+        artifact(
             "com.google.code.findbugs:jsr305",
             repository_name = "rules_jvm_external_deps",
         ),


### PR DESCRIPTION
## MavenPublisher: add commons-logging to fix NoClassDefFoundError in S3 uploads

## Summary
Add `commons-logging:commons-logging` to the `MavenPublisherLib` deps so the AWS SDK Apache client can initialize correctly. This fixes `NoClassDefFoundError: org/apache/commons/logging/LogFactory` during S3 uploads.

## Background
While publishing artifacts to an S3-backed Maven repository using `MavenPublisher`, the tool crashed with:

- `java.lang.NoClassDefFoundError: org/apache/commons/logging/LogFactory`
- Stack trace points to AWS SDK v2 Apache HTTP client (HttpComponents) init path.

`MavenPublisher` uses `software.amazon.awssdk:s3` with the Apache HTTP client, which relies on Apache HttpComponents that in turn expects `commons-logging` at runtime.

## Root Cause
`commons-logging` was not on the classpath of the `MavenPublisher` binary. Bazel targets have hermetic classpaths; only the target’s declared `deps` are available at runtime.

## Change
- In `private/tools/java/com/github/bazelbuild/rules_jvm_external/maven/BUILD`, add:
  - `artifact("commons-logging:commons-logging", repository_name = "rules_jvm_external_deps")` to the `deps` of `MavenPublisherLib`.

## Why here (in rules_jvm_external) and not in a consumer repo?
- Bazel does not have a global classpath. Changing deps in a consumer repo does not affect the classpath of this external tool’s binary.
- The only reliable fix is to declare the dependency in the tool’s own `java_library` (`MavenPublisherLib`) so it is present at runtime.

## Testing
- Build `MavenPublisher` successfully.
- Re-run artifact publishing to S3; upload completes without `NoClassDefFoundError`.